### PR TITLE
Change HTTP stack from Java stuff to sttp

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,12 @@ developers    :=
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
+scalafmtCheck     := true
+scalafmtSbtCheck  := true
+scalafmtOnCompile := true
+
 sbtPlugin    := true
 scalaVersion := "2.12.19"
 
-libraryDependencies += "dev.zio" %% "zio-test" % "2.1.6" % Test
+libraryDependencies += "com.softwaremill.sttp.client3" %% "core"     % "3.9.7"
+libraryDependencies += "dev.zio"                       %% "zio-test" % "2.1.6" % Test

--- a/src/main/scala/com/guizmaii/sbt/publishwithheaders/PublishWithHeadersPlugin.scala
+++ b/src/main/scala/com/guizmaii/sbt/publishwithheaders/PublishWithHeadersPlugin.scala
@@ -14,9 +14,10 @@ object PublishWithHeadersPlugin extends AutoPlugin with PublishWithHeadersKeys {
       val log                  = streams.value.log
       log.info(s"Updating urlHandlerDispatcher to use PublishWithHeadersPlugin")
       val _headers             = headersToPublishWith.value // eager evaluation
+      log.info(s"Headers to publish with: ${_headers.map { case (k, v) => s"$k -> ****${v.takeRight(4)}" }.mkString("(", ", ", ")")}")
       val urlHandlerDispatcher = new URLHandlerDispatcher {
-        super.setDownloader("http", new WithHeadersURLHandler(_headers))
-        super.setDownloader("https", new WithHeadersURLHandler(_headers))
+        super.setDownloader("http", new WithHeadersURLHandler(_headers, log.debug(_)))
+        super.setDownloader("https", new WithHeadersURLHandler(_headers, log.debug(_)))
         override def setDownloader(protocol: String, downloader: URLHandler): Unit = {}
       }
       URLHandlerRegistry.setDefault(urlHandlerDispatcher)

--- a/src/main/scala/com/guizmaii/sbt/publishwithheaders/WithHeadersURLHandler.scala
+++ b/src/main/scala/com/guizmaii/sbt/publishwithheaders/WithHeadersURLHandler.scala
@@ -1,175 +1,52 @@
 package com.guizmaii.sbt.publishwithheaders
 
 import org.apache.ivy.Ivy
-import org.apache.ivy.util.url.{BasicURLHandler, IvyAuthenticator}
-import org.apache.ivy.util.{CopyProgressListener, FileUtil, Message}
-import sbt.internal.librarymanagement.ivyint.ErrorMessageAuthenticator
+import org.apache.ivy.util.CopyProgressListener
+import org.apache.ivy.util.url.BasicURLHandler
 import sbt.{File, URL}
+import sttp.client3.{SimpleHttpClient, basicRequest}
+import sttp.model.Uri
 
-import java.io.{ByteArrayOutputStream, FileInputStream, IOException, InputStream}
-import java.net.{HttpURLConnection, URLConnection}
-
-private[publishwithheaders] final class WithHeadersURLHandler(headers: Seq[(String, String)]) extends BasicURLHandler {
-
-  private val BUFFER_SIZE             = 64 * 1024
-  private val ERROR_BODY_TRUNCATE_LEN = 512
+private[publishwithheaders] final class WithHeadersURLHandler(
+  headers: Seq[(String, String)],
+  logDebug: String => Unit,
+) extends BasicURLHandler {
 
   override def upload(source: File, dest: URL, l: CopyProgressListener): Unit = {
     if (!("http" == dest.getProtocol) && !("https" == dest.getProtocol)) {
       throw new UnsupportedOperationException("URL repository only support HTTP PUT at the moment")
     }
 
-    IvyAuthenticator.install()
-    ErrorMessageAuthenticator.install()
+    logDebug(s"About to upload file ${source.getPath}")
 
-    var conn: HttpURLConnection = null
-    try {
-      val normalDest     = normalizeToURL(dest)
-      conn = normalDest.openConnection.asInstanceOf[HttpURLConnection]
-      conn.setDoOutput(true)
-      conn.setRequestMethod("PUT")
-      conn.setRequestProperty("User-Agent", "Apache Ivy/" + Ivy.getIvyVersion)
-      conn.setRequestProperty("Accept", "application/octet-stream, application/json, application/xml, */*")
-      conn.setRequestProperty("Content-type", "application/octet-stream")
-      conn.setRequestProperty("Content-length", source.length.toString)
-      headers.foreach { case (key, value) => conn.setRequestProperty(key, value) }
-      conn.setInstanceFollowRedirects(true)
-      val in             = new FileInputStream(source)
-      try {
-        val os = conn.getOutputStream
-        FileUtil.copy(in, os, l)
-      } finally
-        try in.close()
-        catch {
-          case _: IOException =>
-        }
-      // initiate the connection
-      val responseCode   = conn.getResponseCode
-      var extra          = ""
-      val errorStream    = conn.getErrorStream
-      val responseStream = conn.getInputStream
-      if (errorStream != null) {
-        extra = "; Response Body: " + readTruncated(errorStream, ERROR_BODY_TRUNCATE_LEN, conn.getContentType, conn.getContentEncoding)
-      } else if (responseStream != null) {
-        // TODO Jules: Find why this `decodingStream` was not used
-        // val decodingStream = getDecodingInputStream(conn.getContentEncoding, responseStream)
-        extra = "; Response Body: " + readTruncated(responseStream, ERROR_BODY_TRUNCATE_LEN, conn.getContentType, conn.getContentEncoding)
-      }
-      Message.debug("Response Headers:" + getHeadersAsDebugString(conn.getHeaderFields))
-      validatePutStatusCode(dest, responseCode, conn.getResponseMessage + extra)
-    } finally disconnect(conn)
-  }
+    SimpleHttpClient { client =>
+      val url = Uri(normalizeToURL(dest).toURI)
 
-  private def getHeadersAsDebugString(headers: java.util.Map[String, java.util.List[String]]): String = {
-    val builder: StringBuilder = new StringBuilder("")
-    if (headers != null) {
-      headers.entrySet().forEach { entry =>
-        val key: String = entry.getKey
-        if (key != null) {
-          builder.append(key)
-          builder.append(": ")
-        }
-        builder.append(String.join("\n    ", entry.getValue))
-        builder.append("\n")
-        ()
-      }
-    }
-    builder.toString
-  }
+      logDebug(s"Url $url")
 
-  /**
-   * Extract the charset from the Content-Type header string, or default to ISO-8859-1 as per
-   * rfc2616-sec3.html#sec3.7.1 .
-   *
-   * @param contentType
-   * the Content-Type header string
-   * @return the charset as specified in the content type, or ISO-8859-1 if unspecified.
-   */
-  private def getCharSetFromContentType(contentType: String): String = {
-    var charSet: String = null
-    if (contentType != null) {
-      val elements = contentType.split(";")
-      for (i <- 0 until elements.length) {
-        val element = elements(i).trim
-        if (element.toLowerCase.startsWith("charset=")) charSet = element.substring("charset=".length)
-      }
-    }
-    if (charSet == null || charSet.isEmpty) {
-      // default to ISO-8859-1 as per rfc2616-sec3.html#sec3.7.1
-      charSet = "ISO-8859-1"
-    }
-    charSet
-  }
+      val request =
+        basicRequest
+          .put(url)
+          .followRedirects(true)
+          .body(source)
+          .headers(
+            // The order of the maps concatenation is important.
+            // We don't want to allow users to override the headers we manually set.
+            headers.toMap ++
+              Map(
+                "User-Agent" -> s"Apache Ivy/${Ivy.getIvyVersion}",
+                "Accept"     -> "application/octet-stream, application/json, application/xml, */*",
+              )
+          )
 
-  @throws[IOException]
-  private def readTruncated(is: InputStream, maxLen: Int, contentType: String, contentEncoding: String) = {
-    val decodingStream = getDecodingInputStream(contentEncoding, is)
-    val charSet        = getCharSetFromContentType(contentType)
-    val os             = new ByteArrayOutputStream(maxLen)
-    try {
-      var count = 0
-      var b     = decodingStream.read
-      while (count < maxLen && b >= 0) {
-        os.write(b)
-        count += 1
-        b = decodingStream.read
-      }
-      new String(os.toByteArray, charSet)
-    } finally {
-      try is.close()
-      catch {
-        case _: IOException =>
-      }
+      logDebug(s"Request: $request")
+
+      val response = client.send(request)
+
+      logDebug(s"Response: $response")
+
+      validatePutStatusCode(dest, response.code.code, s"${response.statusText} - ${response.body.fold(identity, identity)}")
     }
   }
 
-  private def disconnect(con: URLConnection): Unit =
-    con match {
-      case connection: HttpURLConnection =>
-        if (!("HEAD" == connection.getRequestMethod)) {
-          // We must read the response body before disconnecting!
-          // Cfr. http://java.sun.com/j2se/1.5.0/docs/guide/net/http-keepalive.html
-          // [quote]Do not abandon a connection by ignoring the response body. Doing
-          // so may results in idle TCP connections.[/quote]
-          readResponseBody(connection)
-        }
-        connection.disconnect()
-      case _                             =>
-        if (con != null) {
-          try con.getInputStream.close()
-          catch {
-            case _: IOException =>
-          }
-        }
-    }
-
-  private def readResponseBody(conn: HttpURLConnection): Unit = {
-    val buffer                = new Array[Byte](BUFFER_SIZE)
-    var inStream: InputStream = null
-    try {
-      inStream = conn.getInputStream
-      while (inStream.read(buffer) > 0) {}
-    } catch {
-      case _: IOException =>
-    } finally {
-      if (inStream != null) {
-        try inStream.close()
-        catch {
-          case _: IOException =>
-        }
-      }
-    }
-    val errStream = conn.getErrorStream
-    if (errStream != null) {
-      try while (errStream.read(buffer) > 0) {}
-      catch {
-        case _: IOException =>
-      } finally {
-        try errStream.close()
-        catch {
-          case _: IOException =>
-        }
-      }
-    }
-  }
 }


### PR DESCRIPTION
The problem with the Java stuff is that if the user wants to set the `Authorization` header, for some reasons I don't understand, the `conn.setRequestProperty("Authorization", ...)` call doesn't save the header in the request